### PR TITLE
Handling crop dimension when using cropAlias without explicit width a…

### DIFF
--- a/AzureBlobCache.Helpers/Helpers.cs
+++ b/AzureBlobCache.Helpers/Helpers.cs
@@ -29,6 +29,8 @@ namespace AzureBlobCache.Helpers
                      bool upScale = true,
                      bool resolveCdnPath = false)
         {
+			if (cropAlias != null) useCropDimensions = true;
+			
             var cropUrl = ImageCropperTemplateExtensions.GetCropUrl(mediaItem, width, height, propertyAlias, cropAlias, quality, imageCropMode, imageCropAnchor, preferFocalPoint, useCropDimensions, cacheBuster, furtherOptions, ratioMode, upScale);
 
             var cachePrefix = "AzureBlobCache_";


### PR DESCRIPTION
…nd height

I'm using GetCropUrl() extension method to ping cached images in CDN directly and it worked like a charm when I placed width and height of images in parameters. When it takes nulls and according to source code in Umbraco (https://github.com/umbraco/Umbraco-CMS/blob/95cd32ad8ce27993d9550a86950d821a1b4683ad/src/Umbraco.Web/ImageCropperTemplateExtensions.cs) it's required to set **useCropDimension** to **true** then to keep crop dimension.

I placed simple condition checking if cropAlias != null and set this to true then. It fixed the problem. I created small PR, so if you think that this way is good to handle it you can accept it. If not - I'm curious your opinion and point of view here. Thanks for this piece of work!